### PR TITLE
Add visible link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![go report card](https://goreportcard.com/badge/github.com/Myra-Security-GmbH/terraform-provider-myrasec "go report card")](https://goreportcard.com/report/github.com/Myra-Security-GmbH/terraform-provider-myrasec)
 [![release](https://github.com/Myra-Security-GmbH/terraform-provider-myrasec/actions/workflows/release.yml/badge.svg?branch=v1.20.0)](https://github.com/Myra-Security-GmbH/terraform-provider-myrasec/actions/workflows/release.yml)
 
+## Documentation
+
+- [Official documentation](https://registry.terraform.io/providers/Myra-Security-GmbH/myrasec/latest/docs)
+
+
 ## Requirements
 -   [Terraform](https://www.terraform.io/downloads.html)
 -   [Go](https://golang.org/doc/install)


### PR DESCRIPTION
Put a link into readme.md that the customer sees readable documentation when visiting this provider.