### PR TITLE
APEX-218: (fix) add diag detail to tag setting create errors

### DIFF
--- a/myrasec/resource_myrasec_tag_settings.go
+++ b/myrasec/resource_myrasec_tag_settings.go
@@ -372,6 +372,7 @@ func resourceMyrasecTagSettingsCreate(ctx context.Context, d *schema.ResourceDat
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Error updating tag settings",
+			Detail:   formatError(err),
 		})
 		return diags
 	}


### PR DESCRIPTION
Adds the `Detail` field to tag settings create diagnostics