### PR TITLE
MAP-580: Accept header and header_custom WAF condition names

### DIFF
--- a/docs/resources/waf_rule.md
+++ b/docs/resources/waf_rule.md
@@ -95,11 +95,13 @@ matching_type = "EQUALS|GREATER_THAN|LESS_THAN"
 value = "1"
 ```
 ```hcl
-name = "arg|cookie|custom_header|postarg"
+name = "arg|cookie|custom_header|header|header_custom|postarg"
 matching_type = "EXACT|IREGEX|PREFIX|REGEX|SUFFIX|NOT EXACT|NOT IREGEX|NOT PREFIX|NOT REGEX|NOT SUFFIX"
 key = "SOME KEY"
 value = "SOME VALUE"
 ```
+
+`custom_header` is the legacy variant kept for backwards compatibility. New rules should use `header` (matches any standard or custom HTTP header) or `header_custom` (matches only custom headers, rejects standard HTTP header names).
 ```hcl
 name = "country|continent"
 matching_type = "EQUALS|NOT_EQUALS"
@@ -112,7 +114,7 @@ matching_type = "EXACT|IREGEX|PREFIX|REGEX|SUFFIX|NOT EXACT|NOT IREGEX|NOT PREFI
 value = "SOME VALUE"
 ```
 ```hcl
-name = "custom_header"
+name = "custom_header|header|header_custom"
 matching_type = "EXACT|IREGEX|PREFIX|REGEX|SUFFIX|NOT EXACT|NOT IREGEX|NOT PREFIX|NOT REGEX|NOT SUFFIX"
 key = "SOME KEY"
 value = "SOME VALUE"

--- a/myrasec/resource_myrasec_waf_rule.go
+++ b/myrasec/resource_myrasec_waf_rule.go
@@ -31,6 +31,8 @@ var requiredActionKeyValue = []string{
 }
 var requiredConditionKey = []string{
 	"custom_header",
+	"header",
+	"header_custom",
 	"cookie",
 	"arg",
 	"postarg",


### PR DESCRIPTION
Adds the two new condition names to the requiredConditionKey list so the provider validates that a key is supplied for them (same shape as the legacy custom_header and arg / cookie / postarg conditions). The condition payload itself flows through unchanged since condition names are passed as strings. Documents the new names in the WAF rule resource docs alongside the legacy custom_header, noting that header_custom rejects standard HTTP header names on the API side.